### PR TITLE
[master] Pipeline Git checkout fix - environment variable GIT_BRANCH refactor

### DIFF
--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -9,7 +9,7 @@
 //  SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 // Job input parameters:
-//   GIT_BRANCH           - Branch to release
+//   GIT_BRANCH_RELEASE   - Branch to release
 
 // Job internal argumets:
 //   GIT_USER_NAME       - Git user name (for commits)
@@ -34,7 +34,7 @@ pipeline {
         // Initialize build environment
         stage('Init') {
             steps {
-                git branch: GIT_BRANCH, credentialsId: SSH_CREDENTIALS_ID, url: GIT_REPOSITORY_URL
+                git branch: GIT_BRANCH_RELEASE, credentialsId: SSH_CREDENTIALS_ID, url: GIT_REPOSITORY_URL
                 withCredentials([file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING')]) {
                     sh label: '', script: '''
                         gpg --batch --import "${KEYRING}"

--- a/etc/jenkins/release.groovy
+++ b/etc/jenkins/release.groovy
@@ -18,6 +18,7 @@
 // Job internal argumets:
 //   GIT_USER_NAME       - Git user name (for commits)
 //   GIT_USER_EMAIL      - Git user e-mail (for commits)
+//   GIT_BRANCH_RELEASE  - Git branch to release
 //   SSH_CREDENTIALS_ID  - Jenkins ID of SSH credentials
 //   GPG_CREDENTIALS_ID  - Jenkins ID of GPG credentials (stored as KEYRING variable)
 
@@ -117,7 +118,7 @@ spec:
         stage('Init') {
             steps {
                 container('el-build') {
-                    git branch: GIT_BRANCH, credentialsId: SSH_CREDENTIALS_ID, url: GIT_REPOSITORY_URL
+                    git branch: GIT_BRANCH_RELEASE, credentialsId: SSH_CREDENTIALS_ID, url: GIT_REPOSITORY_URL
                     withCredentials([file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING')]) {
                         sh label: '', script: '''
                             gpg --batch --import "${KEYRING}"
@@ -138,7 +139,7 @@ spec:
         stage('Build and release Oracle DDL Parser') {
             steps {
                 container('el-build') {
-                    git branch: GIT_BRANCH, credentialsId: SSH_CREDENTIALS_ID, url: GIT_REPOSITORY_URL
+                    git branch: GIT_BRANCH_RELEASE, credentialsId: SSH_CREDENTIALS_ID, url: GIT_REPOSITORY_URL
                     sshagent(['SSH_CREDENTIALS_ID']) {
                         sh '''
                             etc/jenkins/release.sh "${DDLPARSER_VERSION}" "${NEXT_DDLPARSER_VERSION}" "${DRY_RUN}" "${OVERWRITE}"


### PR DESCRIPTION
Environment variable GIT_BRANCH was renamed to GIT_BRANCH_RELEASE due a bug
https://bugs.eclipse.org/bugs/show_bug.cgi?id=566931

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>