### PR TITLE
Release pipeline SSH_CREDENTIALS_ID change

### DIFF
--- a/etc/jenkins/release.groovy
+++ b/etc/jenkins/release.groovy
@@ -140,7 +140,7 @@ spec:
             steps {
                 container('el-build') {
                     git branch: GIT_BRANCH_RELEASE, credentialsId: SSH_CREDENTIALS_ID, url: GIT_REPOSITORY_URL
-                    sshagent(['SSH_CREDENTIALS_ID']) {
+                    sshagent([SSH_CREDENTIALS_ID]) {
                         sh '''
                             etc/jenkins/release.sh "${DDLPARSER_VERSION}" "${NEXT_DDLPARSER_VERSION}" "${DRY_RUN}" "${OVERWRITE}"
                         '''


### PR DESCRIPTION
Small fix for release job (git push operation credentials).

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>