### PR TITLE
Travis-CI initial implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0,
+# or the Eclipse Distribution License v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+language: java
+dist: focal
+
+env:
+  global:
+    - MAVEN_OPTS="-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+
+jobs:
+  allow_failures:
+    - jdk: openjdk-ea
+
+jdk:
+  - openjdk11
+  - openjdk-ea
+
+cache:
+  directories:
+    - $HOME/.m2
+
+script:
+  - echo 'RUNNING TESTS, BE PATIENT...'
+  - echo 'ENVIRONMENT:'
+  - env
+  - set -o pipefail
+  - cd oracleddlparser
+  - mvn clean install -Dgpg.skip=true -Poss-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,6 @@
 language: java
 dist: focal
 
-env:
-  global:
-    - MAVEN_OPTS="-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
-
-jobs:
-  allow_failures:
-    - jdk: openjdk-ea
-
 jdk:
   - openjdk11
   - openjdk-ea
@@ -33,6 +25,5 @@ script:
   - echo 'RUNNING TESTS, BE PATIENT...'
   - echo 'ENVIRONMENT:'
   - env
-  - set -o pipefail
   - cd oracleddlparser
-  - mvn clean install -Dgpg.skip=true -Poss-release
+  - mvn clean package -Dgpg.skip=true -Poss-release


### PR DESCRIPTION
This Travis-CI integration verifies if project is build-able (include javadoc) on JDK 11 and JDK-EA (currently JDK 17). Tests are not executed due unavailable Oracle DB in public environment.
As a part of merge process of this PR must be Travis-CI integration (repository access) enabled by project owner/admin in GitHub project settings.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>