### PR TITLE
Jenkins build - publish to Jakarta snapshots

### DIFF
--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -50,7 +50,7 @@ pipeline {
                 '''
             }
         }
-        // Perform release
+        // Build
         stage('Build') {
             steps {
                 sshagent([SSH_CREDENTIALS_ID]) {
@@ -60,6 +60,13 @@ pipeline {
                 }
             }
         }
-
+        // Publish to snapshots
+        stage('Publish to snapshots') {
+            steps {
+                sh '''
+                    etc/jenkins/publish_snapshots.sh
+                '''
+            }
+        }
     }
 }

--- a/etc/jenkins/publish_snapshots.sh
+++ b/etc/jenkins/publish_snapshots.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Distribution License v. 1.0, which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+#
+# Arguments:
+#  N/A
+
+if [ "${CONTINUOUS_BUILD}" = "true" ]; then
+    echo '-[ Oracle DDL Parser publish to Jakarta Snapshots -> No publishing any artifacts]-----------------------------------------------------------'
+else
+    echo '-[ Oracle DDL Parser publish to Jakarta Snapshots ]-----------------------------------------------------------'
+    cd "${DDLPARSER_DIR}"
+    mvn --no-transfer-progress -U -C -B -V \
+      -Psnapshots -DskipTests \
+      -Ddoclint=none -Ddeploy \
+      deploy
+fi


### PR DESCRIPTION
Publish to Jakarta snapshots during nightly build and some Groovy and shell scripts renaming as ASM project is standalone project.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>